### PR TITLE
Fix public events calendarjs API

### DIFF
--- a/website/events/api/serializers.py
+++ b/website/events/api/serializers.py
@@ -83,7 +83,9 @@ class EventCalenderJSSerializer(CalenderJSSerializer):
 
     def _class_names(self, instance):
         class_names = ["regular-event"]
-        if services.is_user_registered(self.context["member"], instance):
+        if self.context["member"] and services.is_user_registered(
+            self.context["member"], instance
+        ):
             class_names.append("has-registration")
         return class_names
 


### PR DESCRIPTION
Closes #1022

#### Previous behaviour
Steps to reproduce:

1. Open the calendarjs API when not logged in using  https://thalia.nu/api/v1/events/calendarjs/?start=2019-07-01T00:00:00&end=2020-07-01T00:00:00
2. Crash

#### New behaviour
Steps to validate that it works:

1. Open the calendarjs API when not logged in
2. Does not crash